### PR TITLE
[Feat] Documentation in sidebar

### DIFF
--- a/components/Sidebar.tsx
+++ b/components/Sidebar.tsx
@@ -3,6 +3,7 @@ import {
   CheckIcon,
   ChevronDownIcon,
   ChevronUpIcon,
+  QuestionMarkIcon,
 } from "@radix-ui/react-icons";
 import * as Select from "@radix-ui/react-select";
 import { tzip16 } from "@taquito/tzip16";
@@ -463,6 +464,29 @@ const Sidebar = ({
           </svg>
           <span>History</span>
         </Link>
+        <a
+          href="https://docs.tzsafe.marigold.dev"
+          target="_blank"
+          rel="noreferrer"
+          className={linkClass(false)}
+        >
+          <svg
+            xmlns="http://www.w3.org/2000/svg"
+            width="18"
+            height="18"
+            viewBox="0 0 24 24"
+            fill="none"
+            stroke="currentColor"
+            strokeWidth="2"
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            className="scale-150"
+          >
+            <path d="M9.09 9a3 3 0 0 1 5.83 1c0 2-3 3-3 3"></path>
+            <line x1="12" y1="17" x2="12.01" y2="17"></line>
+          </svg>
+          <span>Help</span>
+        </a>
       </div>
     </aside>
   );

--- a/components/Sidebar.tsx
+++ b/components/Sidebar.tsx
@@ -3,7 +3,6 @@ import {
   CheckIcon,
   ChevronDownIcon,
   ChevronUpIcon,
-  QuestionMarkIcon,
 } from "@radix-ui/react-icons";
 import * as Select from "@radix-ui/react-select";
 import { tzip16 } from "@taquito/tzip16";


### PR DESCRIPTION
# Description

It was mentioned during the demo day that we want to have another documentation link, so here it is in the sidebar:

![image](https://user-images.githubusercontent.com/36401048/233083651-2bbaae5f-802f-43e3-949e-e23c6a8aa87b.png)
