### PR TITLE
[Fix] fail to pass env

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,14 +20,14 @@ COPY --from=deps /app/node_modules ./node_modules
 
 COPY . .
 
-RUN npm run build
-
 RUN \
   if [ "$ENV" = "prod" ]; then \
     echo -en "NEXT_PUBLIC_RPC_URL=https://mainnet.tezos.marigold.dev/\nNEXT_PUBLIC_API_URL=https://api.tzkt.io\nNEXT_PUBLIC_NETWORK_TYPE=mainnet" > .env.local; \
   else \
     echo -en "NEXT_PUBLIC_RPC_URL=https://ghostnet.tezos.marigold.dev/\nNEXT_PUBLIC_API_URL=https://api.ghostnet.tzkt.io\nNEXT_PUBLIC_NETWORK_TYPE=ghostnet" > .env.local; \
   fi
+
+RUN npm run build
 
 EXPOSE 80
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,6 @@ FROM node:16-alpine AS deps
 RUN apk add --no-cache libc6-compat
 WORKDIR /app
 
-ARG ENV=dev
 # Install dependencies based on the preferred package manager
 COPY package.json yarn.lock* package-lock.json* pnpm-lock.yaml* ./
 RUN \
@@ -15,6 +14,7 @@ RUN \
   fi
 
 FROM node:16-alpine AS builder
+ARG ENV=dev
 WORKDIR /app
 COPY --from=deps /app/node_modules ./node_modules
 


### PR DESCRIPTION
Currently, tzsafe.marigold.dev is running on ghostnet due to wrong env.

There are two bugs here.

1. In docker file, the arg in `ARG` will be wiped up after `FROM` so  we couldn't make release image on mainnet.
```
> docker run --name tzsafe  -p 20000:80 ghcr.io/marigold-dev/tzsafe:0.5.0-release
> docker exec tzsafe cat /app/.env.local
NEXT_PUBLIC_RPC_URL=https://ghostnet.tezos.marigold.dev/
NEXT_PUBLIC_API_URL=https://api.ghostnet.tzkt.io
NEXT_PUBLIC_NETWORK_TYPE=ghostnet
```

2. according to the Next.js [doc](https://nextjs.org/docs/basic-features/environment-variables), the env variables have to be ready before `npm run build`.
> Note: In order to keep server-only secrets safe, environment variables are evaluated at build time