### PR TITLE
[Fix] Allowing floats in amounts

### DIFF
--- a/components/transferForm.tsx
+++ b/components/transferForm.tsx
@@ -188,7 +188,7 @@ function Basic({
         </div>
         <div className="flex w-full flex-col">
           <div className="flex w-full flex-col items-start">
-            <label className="font-medium text-white">Amount</label>
+            <label className="font-medium text-white">Amount (Tez)</label>
             <Field name={`transfers.${id}.amount`}>
               {({ field }: FieldProps) => (
                 <input

--- a/versioned/interface.ts
+++ b/versioned/interface.ts
@@ -201,7 +201,7 @@ abstract class Versioned {
             path: ".amount",
             placeholder: "1",
             validate: (x: string) => {
-              const amount = Number.parseInt(x);
+              const amount = Number(x);
               if (isNaN(amount) || amount <= 0) {
                 return `Invalid amount ${x}`;
               }
@@ -238,7 +238,7 @@ abstract class Versioned {
             path: ".amount",
             placeholder: "1",
             validate: (x: string) => {
-              const amount = Number.parseInt(x);
+              const amount = Number(x);
               if (isNaN(amount) || amount <= 0) {
                 return `Invalid amount ${x}`;
               }
@@ -312,7 +312,7 @@ abstract class Versioned {
           path: ".amount",
           placeholder: "1",
           validate: (x: string) => {
-            const amount = parseInt(x);
+            const amount = Number(x);
             if (isNaN(amount) || amount <= 0) {
               return `Invalid amount ${x}`;
             }


### PR DESCRIPTION
# Description

Because previous amounts were in Mutez, only ints where allowed, so now floats as well are valid inputs