### PR TITLE
Ci 

### DIFF
--- a/.github/workflows/build_tzsafe.yml
+++ b/.github/workflows/build_tzsafe.yml
@@ -36,8 +36,8 @@ jobs:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           release_branches: release
           pre_release_branches: main
-          default_bump: patch
-          default_prerelease_bump: prerelease
+          default_bump: minor
+          default_prerelease_bump: prepatch
           append_to_pre_release_tag: rc
 
       - name: Build


### PR DESCRIPTION
Following : 
Chiachi :
so follow the above idea, I think:
for X => we bump manual through CI
for Y => automatically bump version when merge PR to release branch. Then, semver can deploy the built image to [tzsafe.marigold.dev](http://tzsafe.marigold.dev/)
for Z => automatically bump version when merge PR to main  branch. Then, semver can deploy the built image to [ghostnet.tzsafe.marigold.dev](http://ghostnet.tzsafe.marigold.dev/).
what do you think?

Bump Y version in case on release branch
https://github.com/Laucans/tzsafe-ui/actions/runs/4916062283/jobs/8779499946

Bump Z version in case on release branch :
https://github.com/Laucans/tzsafe-ui/actions/runs/4916159804
