### PR TITLE
[Feature] Multiple FA2 tokens transfer

### DIFF
--- a/components/Select.tsx
+++ b/components/Select.tsx
@@ -44,7 +44,7 @@ const Select = <T,>({
   });
 
   return (
-    <div className={`relative z-[1] w-full text-white ${className ?? ""}`}>
+    <div className={`relative w-full text-white ${className ?? ""}`}>
       <Ariakit.SelectLabel store={select}>{label}</Ariakit.SelectLabel>
       <Ariakit.Select
         store={select}
@@ -62,6 +62,7 @@ const Select = <T,>({
       <Ariakit.SelectPopover
         store={select}
         className="relative mt-1 max-h-52 space-y-1 overflow-y-auto overscroll-contain rounded bg-zinc-700"
+        style={{ zIndex: 2 }}
       >
         <div className="sticky top-0 z-[1] bg-zinc-700 px-2 pt-2">
           <input
@@ -74,21 +75,25 @@ const Select = <T,>({
           />
         </div>
         {loading ? (
-          <div className="flex h-full w-full items-center justify-center px-2">
+          <div className="flex h-full w-full items-center justify-center p-2">
             <Spinner />
           </div>
         ) : (
           <div className="space-y-2 px-2 pb-2">
-            {options.map(v => (
-              <Ariakit.SelectItem
-                key={v.id}
-                className="combobox-item cursor-pointer rounded p-2"
-                value={v.value}
-                setValueOnClick
-              >
-                {renderOption?.(v) ?? v.label}
-              </Ariakit.SelectItem>
-            ))}
+            {options.length === 0 ? (
+              <p className="py-2 text-center text-zinc-500">No result</p>
+            ) : (
+              options.map(v => (
+                <Ariakit.SelectItem
+                  key={v.id}
+                  className="combobox-item cursor-pointer rounded p-2"
+                  value={v.value}
+                  setValueOnClick
+                >
+                  {renderOption?.(v) ?? v.label}
+                </Ariakit.SelectItem>
+              ))
+            )}
           </div>
         )}
 

--- a/components/transferForm.tsx
+++ b/components/transferForm.tsx
@@ -24,7 +24,7 @@ import { AppStateContext, contractStorage } from "../context/state";
 import { mutezToTez, tezToMutez } from "../utils/tez";
 import { debounce } from "../utils/timeout";
 import { VersionedApi } from "../versioned/apis";
-import { Versioned } from "../versioned/interface";
+import { Versioned, proposals } from "../versioned/interface";
 import Alias from "./Alias";
 import ExecuteForm from "./ContractExecution";
 import FA2Transfer from "./FA2Transfer";
@@ -388,20 +388,7 @@ const addNewField = (
   if (window.scrollY > 200) window.scrollTo(0, 0);
 };
 
-const initialProps: {
-  transfers: {
-    type: "lambda" | "transfer" | "contract" | "fa2";
-    values: { [key: string]: string };
-    fields: {
-      field: string;
-      label: string;
-      kind?: "textarea" | "input-complete" | "autocomplete";
-      path: string;
-      placeholder: string;
-      validate: (p: string) => string | undefined;
-    }[];
-  }[];
-} = {
+const initialProps: proposals = {
   transfers: [],
 };
 
@@ -746,6 +733,7 @@ function TransferForm(
                             </div>
                           );
                         } else if (transfer.type === "fa2") {
+                          console.log(values);
                           return (
                             <section key={`${transfer.type}:${index}`}>
                               <p className="text-lg text-white">
@@ -756,7 +744,7 @@ function TransferForm(
                               </p>
                               <FA2Transfer
                                 key={index}
-                                index={index}
+                                proposalIndex={index}
                                 setFieldValue={setFieldValue}
                                 getFieldProps={getFieldProps}
                                 remove={remove}

--- a/package-lock.json
+++ b/package-lock.json
@@ -19,6 +19,7 @@
         "@types/node": "18.11.9",
         "@types/react": "18.0.25",
         "@types/react-dom": "18.0.9",
+        "@types/uuid": "^9.0.1",
         "assert-never": "^1.2.1",
         "bignumber.js": "^9.1.1",
         "eslint": "8.28.0",
@@ -28,7 +29,8 @@
         "next": "13.1.6",
         "react": "18.2.0",
         "react-dom": "18.2.0",
-        "typescript": "4.9.3"
+        "typescript": "4.9.3",
+        "uuid": "^9.0.0"
       },
       "devDependencies": {
         "@trivago/prettier-plugin-sort-imports": "^4.0.0",
@@ -2109,6 +2111,11 @@
     "node_modules/@types/scheduler": {
       "version": "0.16.2",
       "license": "MIT"
+    },
+    "node_modules/@types/uuid": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-9.0.1.tgz",
+      "integrity": "sha512-rFT3ak0/2trgvp4yYZo5iKFEPsET7vKydKF+VRCxlQ9bpheehyAJH89dAkaLEq/j/RZXJIqcgsmPJKUP1Z28HA=="
     },
     "node_modules/@typescript-eslint/parser": {
       "version": "5.44.0",
@@ -6731,6 +6738,14 @@
       "version": "1.0.2",
       "license": "MIT"
     },
+    "node_modules/uuid": {
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.0.tgz",
+      "integrity": "sha512-MXcSTerfPa4uqyzStbRoTgt5XIe3x5+42+q1sDuy3R5MDk66URdLMOZe5aPX/SQd+kuYAh0FdP/pO28IkQyTeg==",
+      "bin": {
+        "uuid": "dist/bin/uuid"
+      }
+    },
     "node_modules/vite": {
       "version": "4.2.1",
       "dev": true,
@@ -8381,6 +8396,11 @@
     },
     "@types/scheduler": {
       "version": "0.16.2"
+    },
+    "@types/uuid": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-9.0.1.tgz",
+      "integrity": "sha512-rFT3ak0/2trgvp4yYZo5iKFEPsET7vKydKF+VRCxlQ9bpheehyAJH89dAkaLEq/j/RZXJIqcgsmPJKUP1Z28HA=="
     },
     "@typescript-eslint/parser": {
       "version": "5.44.0",
@@ -11023,6 +11043,11 @@
     },
     "util-deprecate": {
       "version": "1.0.2"
+    },
+    "uuid": {
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.0.tgz",
+      "integrity": "sha512-MXcSTerfPa4uqyzStbRoTgt5XIe3x5+42+q1sDuy3R5MDk66URdLMOZe5aPX/SQd+kuYAh0FdP/pO28IkQyTeg=="
     },
     "vite": {
       "version": "4.2.1",

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "@types/node": "18.11.9",
     "@types/react": "18.0.25",
     "@types/react-dom": "18.0.9",
+    "@types/uuid": "^9.0.1",
     "assert-never": "^1.2.1",
     "bignumber.js": "^9.1.1",
     "eslint": "8.28.0",
@@ -36,7 +37,8 @@
     "next": "13.1.6",
     "react": "18.2.0",
     "react-dom": "18.2.0",
-    "typescript": "4.9.3"
+    "typescript": "4.9.3",
+    "uuid": "^9.0.0"
   },
   "devDependencies": {
     "@trivago/prettier-plugin-sort-imports": "^4.0.0",

--- a/versioned/interface.ts
+++ b/versioned/interface.ts
@@ -8,6 +8,30 @@ import { ownersForm } from "./forms";
 
 export type timeoutAndHash = [boolean, string];
 
+type common = {
+  fields: {
+    field: string;
+    label: string;
+    path: string;
+    placeholder: string;
+    kind?: "textarea" | "input-complete" | "autocomplete";
+    validate: (p: string) => string | undefined;
+  }[];
+};
+export type proposals =
+  | {
+      transfers: ({
+        type: "transfer" | "lambda" | "contract";
+        values: { [key: string]: string };
+      } & common)[];
+    }
+  | {
+      transfers: ({
+        type: "fa2";
+        values: { [key: string]: string }[];
+      } & common)[];
+    };
+
 abstract class Versioned {
   readonly version: string;
   readonly contractAddress: string;
@@ -18,19 +42,7 @@ abstract class Versioned {
   abstract submitTxProposals(
     cc: Contract,
     t: TezosToolkit,
-    proposals: {
-      transfers: {
-        type: "transfer" | "lambda" | "contract" | "fa2";
-        values: { [key: string]: string };
-        fields: {
-          field: string;
-          label: string;
-          path: string;
-          placeholder: string;
-          validate: (p: string) => string | undefined;
-        }[];
-      }[];
-    }
+    proposals: proposals
   ): Promise<timeoutAndHash>;
 
   abstract signProposal(
@@ -266,7 +278,7 @@ abstract class Versioned {
   }
 
   static fa2(c: contractStorage): {
-    values: { [key: string]: string };
+    values: { [key: string]: string }[];
     fields: {
       field: string;
       label: string;
@@ -277,11 +289,13 @@ abstract class Versioned {
     }[];
   } {
     return {
-      values: {
-        token: "",
-        amount: "",
-        targetAddress: "",
-      },
+      values: [
+        {
+          token: "",
+          amount: "",
+          targetAddress: "",
+        },
+      ],
       fields: [
         {
           field: "token",

--- a/versioned/version011.ts
+++ b/versioned/version011.ts
@@ -19,9 +19,8 @@ import { contractStorage } from "../types/app";
 import { proposal, proposalContent, status } from "../types/display";
 import { tezToMutez } from "../utils/tez";
 import { promiseWithTimeout } from "../utils/timeout";
-import { matchLambda } from "./apis";
 import { ownersForm } from "./forms";
-import { timeoutAndHash, Versioned } from "./interface";
+import { proposals, timeoutAndHash, Versioned } from "./interface";
 
 function convert(x: string): string {
   return char2Bytes(x);
@@ -30,19 +29,7 @@ class Version011 extends Versioned {
   async submitTxProposals(
     cc: Contract,
     t: TezosToolkit,
-    proposals: {
-      transfers: {
-        type: "transfer" | "lambda" | "contract" | "fa2";
-        values: { [key: string]: string };
-        fields: {
-          field: string;
-          label: string;
-          path: string;
-          placeholder: string;
-          validate: (p: string) => string | undefined;
-        }[];
-      }[];
-    }
+    proposals: proposals
   ): Promise<[boolean, string]> {
     let params = cc.methods
       .create_proposal(
@@ -84,32 +71,32 @@ class Version011 extends Versioned {
               };
             }
             case "fa2": {
-              const parser = new Parser();
-              const michelsonCode = parser.parseMichelineExpression(
-                makeFa2Michelson({
-                  walletAddress: cc.address,
-                  targetAddress: x.values.targetAddress,
-                  tokenId: Number(x.values.tokenId),
-                  amount: Number(x.values.amount),
-                  fa2Address: x.values.fa2Address,
-                })
-              );
-
-              return {
-                execute_lambda: {
-                  metadata: convert(
-                    JSON.stringify({
-                      contract_addr: x.values.targetAddress,
-                      payload: {
-                        token_id: Number(x.values.tokenId),
-                        fa2_address: x.values.fa2Address,
-                      },
-                      amount: Number(x.values.amount),
-                    })
-                  ),
-                  lambda: michelsonCode,
-                },
-              };
+              // TODO: HANDLE FA2 ARRAY
+              // const parser = new Parser();
+              // const michelsonCode = parser.parseMichelineExpression(
+              //   makeFa2Michelson({
+              //     walletAddress: cc.address,
+              //     targetAddress: x.values.targetAddress,
+              //     tokenId: Number(x.values.tokenId),
+              //     amount: Number(x.values.amount),
+              //     fa2Address: x.values.fa2Address,
+              //   })
+              // );
+              // return {
+              //   execute_lambda: {
+              //     metadata: convert(
+              //       JSON.stringify({
+              //         contract_addr: x.values.targetAddress,
+              //         payload: {
+              //           token_id: Number(x.values.tokenId),
+              //           fa2_address: x.values.fa2Address,
+              //         },
+              //         amount: Number(x.values.amount),
+              //       })
+              //     ),
+              //     lambda: michelsonCode,
+              //   },
+              // };
             }
             default:
               return {};


### PR DESCRIPTION
# Description
This PR adds allow to transfer multiple fa2 tokens from the same contract at the same time:
- You can new fields
- New fields should only search tokens from the same contract than the first
- Once a token is selected it can't appear anymore in the search
- if first token change, it reset all the tokens after