### PR TITLE
[Fix] exact match lambda pattern

### DIFF
--- a/context/parseLambda.ts
+++ b/context/parseLambda.ts
@@ -4,7 +4,6 @@ import {
   validateAddress,
   ValidationResult,
 } from "@taquito/utils";
-import { parse } from "path";
 import { decodeB58 } from "../utils/contractParam";
 
 export type primitiveName = "string" | "number" | "list";

--- a/tests/lambdaParsing.spec.ts
+++ b/tests/lambdaParsing.spec.ts
@@ -15,8 +15,6 @@ const FA2_LAMBDA = p.parseMichelineExpression(`{
             Pair "targetAddress2" (Pair 2 12) ;
             Pair "targetAddress3" (Pair 3 13) ;
       
-        }
-      
     } };
     TRANSFER_TOKENS
   }`)!;

--- a/tests/lambdaParsing.spec.ts
+++ b/tests/lambdaParsing.spec.ts
@@ -39,13 +39,136 @@ const FA1_2_TRANSFER_LAMBDA = p.parseMichelineExpression(`{
     TRANSFER_TOKENS
   }`)!;
 
-describe("parseLambda", () => {
+const DELEGATE_LAMBDA = p.parseMichelineExpression(`{
+  DROP ;
+  PUSH key_hash "baker_addr" ;
+  SOME ;
+  SET_DELEGATE ;
+}`)!;
+
+const UN_DELEGATE_LAMBDA = p.parseMichelineExpression(`{
+  DROP ;
+  NONE key_hash ;
+  SET_DELEGATE ;
+}`)!;
+
+const DEFAULT_ENTRYPOINT_LAMBDA = p.parseMichelineExpression(`{
+    DROP;
+    PUSH address "test_address";
+    CONTRACT (list (pair (address %from_) (list %txs (pair (address %to_) (pair (nat %token_id) (nat %amount))))));
+    IF_NONE { PUSH string "contract dosen't exist" ; FAILWITH } { } ;
+    PUSH mutez 0 ;
+    PUSH (list (pair (address %from_) (list %txs (pair (address %to_) (pair (nat %token_id) (nat %amount)))))) {Pair "walletAddress" {
+      
+            Pair "targetAddress1" (Pair 1 11) ;
+            Pair "targetAddress2" (Pair 2 12) ;
+            Pair "targetAddress3" (Pair 3 13) ;
+      
+    } };
+    TRANSFER_TOKENS
+  }`)!;
+
+const DROP_DELEGATE_LAMBDA = p.parseMichelineExpression(`{
+    DROP ;
+    NONE key_hash ;
+    SET_DELEGATE ;
+    DROP;
+  }`)!;
+
+const DROP_OP_IN_IF_BRANCH_LAMBDA = p.parseMichelineExpression(`{
+    DROP;
+    PUSH address "test_address";
+    CONTRACT (list (pair (address %from_) (list %txs (pair (address %to_) (pair (nat %token_id) (nat %amount))))));
+    IF_NONE { PUSH string "contract dosen't exist" ; FAILWITH } { DROP; } ;
+    PUSH mutez 0 ;
+    PUSH (list (pair (address %from_) (list %txs (pair (address %to_) (pair (nat %token_id) (nat %amount)))))) {Pair "walletAddress" {
+      
+            Pair "targetAddress1" (Pair 1 11) ;
+            Pair "targetAddress2" (Pair 2 12) ;
+            Pair "targetAddress3" (Pair 3 13) ;
+      
+    } };
+    TRANSFER_TOKENS
+  }`)!;
+
+describe("parseLambda 1", () => {
+  it("should parse the set delegate lambda", () => {
+    const [lambdaType, data] = parseLambda(DELEGATE_LAMBDA);
+
+    expect(lambdaType).toBe(LambdaType.DELEGATE);
+    expect(data).toMatchObject({
+      contractAddress: "",
+      data: { address: "baker_addr" },
+      entrypoint: { name: "", params: { name: "", type: "" } },
+    });
+  });
+
+  it("should parse the unset delegate lambda", () => {
+    const [lambdaType, data] = parseLambda(UN_DELEGATE_LAMBDA);
+
+    expect(lambdaType).toBe(LambdaType.UNDELEGATE);
+    expect(data).toMatchObject({
+      contractAddress: "",
+      data: {},
+      entrypoint: { name: "", params: { name: "", type: "" } },
+    });
+  });
+
+  it("should parse the default entrypoint lambda", () => {
+    const [lambdaType, data] = parseLambda(DEFAULT_ENTRYPOINT_LAMBDA);
+
+    expect(lambdaType).toBe(LambdaType.CONTRACT_EXECUTION);
+    expect(data).toMatchObject({
+      contractAddress: "test_address",
+      entrypoint: {
+        name: "",
+        params: {
+          name: undefined,
+          type: "list",
+          children: [
+            {
+              name: undefined,
+              type: "pair",
+              children: [
+                { name: "from_", type: "address" },
+                {
+                  name: "txs",
+                  type: "list",
+                  children: [
+                    {
+                      name: undefined,
+                      type: "pair",
+                      children: [
+                        { name: "to_", type: "address" },
+                        {
+                          type: "pair",
+                          name: undefined,
+                          children: [
+                            { name: "token_id", type: "nat" },
+                            { name: "amount", type: "nat" },
+                          ],
+                        },
+                      ],
+                    },
+                  ],
+                },
+              ],
+            },
+          ],
+        },
+      },
+      data: `{Pair "walletAddress" {Pair "targetAddress1" (Pair 1 11); Pair "targetAddress2" (Pair 2 12); Pair "targetAddress3" (Pair 3 13)}}`,
+      mutez: 0,
+    });
+  });
+
   it("should parse the fa2 lambda", () => {
     const [lambdaType, data] = parseLambda(FA2_LAMBDA);
 
     expect(lambdaType).toBe(LambdaType.FA2);
     expect(data).toMatchObject({
       contractAddress: "fa2address",
+      mutez: 0,
       entrypoint: {
         name: "transfer",
         params: {
@@ -113,6 +236,7 @@ describe("parseLambda", () => {
           ],
         },
       },
+      mutez: 0,
       data: {
         spender: "spenderAddress",
         value: 1,
@@ -143,11 +267,28 @@ describe("parseLambda", () => {
           ],
         },
       },
+      mutez: 0,
       data: {
         from: "walletAddress",
         to: "targetAddress",
         amount: 1,
       },
     });
+  });
+});
+
+describe("parseLambda 2", () => {
+  it("should be parse as lambda execution 1", () => {
+    const [lambdaType, data] = parseLambda(DROP_DELEGATE_LAMBDA);
+
+    expect(lambdaType).toBe(LambdaType.LAMBDA_EXECUTION);
+    expect(data).toBeUndefined;
+  });
+
+  it("should be parse as lambda execution 2", () => {
+    const [lambdaType, data] = parseLambda(DROP_OP_IN_IF_BRANCH_LAMBDA);
+
+    expect(lambdaType).toBe(LambdaType.LAMBDA_EXECUTION);
+    expect(data).toBeUndefined;
   });
 });


### PR DESCRIPTION
If the lambda pattern does not exactly match the pattern of an FA2 transfer, FA1 transfer/approval, or (un)setting delegate, it will be classified as a lambda execution.



cc: @tj825 