### PR TITLE
[Feat] Version detection

### DIFF
--- a/components/RenderProposalContentLambda.tsx
+++ b/components/RenderProposalContentLambda.tsx
@@ -119,7 +119,10 @@ export const contentToData = (
     const parser = new Parser();
 
     const [type, lambda] = parseLambda(
-      parser.parseMichelineExpression(content.executeLambda.content ?? "")
+      // Required for version 0.0.10
+      typeof content.executeLambda.content === "string"
+        ? parser.parseMichelineExpression(content.executeLambda.content ?? "")
+        : content.executeLambda.content ?? null
     );
 
     if (type === LambdaType.LAMBDA_EXECUTION) {
@@ -404,7 +407,10 @@ export const labelOfProposalContentLambda = (content: proposalContent) => {
     const parser = new Parser();
 
     const [type, _] = parseLambda(
-      parser.parseMichelineExpression(content.executeLambda.content ?? "")
+      // Required for version 0.0.10
+      typeof content.executeLambda.content === "string"
+        ? parser.parseMichelineExpression(content.executeLambda.content ?? "")
+        : content.executeLambda.content ?? null
     );
 
     return type === LambdaType.FA2

--- a/components/Sidebar.tsx
+++ b/components/Sidebar.tsx
@@ -133,17 +133,6 @@ const Sidebar = ({
   }, []);
 
   useEffect(() => {
-    const entries = Object.entries(state.contracts);
-
-    if (entries.length === 0 || !!state.currentContract) return;
-
-    dispatch({
-      type: "setCurrentContract",
-      payload: entries[0][0],
-    });
-  }, [state.contracts]);
-
-  useEffect(() => {
     if (!state.currentContract) return;
 
     (async () => {

--- a/components/create/createLoader.tsx
+++ b/components/create/createLoader.tsx
@@ -40,14 +40,14 @@ function Success() {
               },
             })
             .send();
-          let result1 = await deploy?.contract();
-          let c = await result1!.storage();
-          let ct = await state?.connection.contract.at(
+          const result1 = await deploy?.contract();
+          const c = await result1!.storage();
+          const ct = await state?.connection.contract.at(
             result1?.address!,
             tzip16
           )!;
-          let version = await fetchVersion(ct);
-          let balance = await state?.connection.tz.getBalance(
+          const version = await fetchVersion(ct);
+          const balance = await state?.connection.tz.getBalance(
             result1!.address!
           );
           setAddress({ address: result1?.address!, status: 1 });

--- a/context/metadata.ts
+++ b/context/metadata.ts
@@ -17,11 +17,17 @@ const dispatch: { [key: string]: version } = {
   "0.1.1": "0.1.1",
 };
 
-const VERSION_HASH: { [k: string]: version } = {
-  "-357299388-2016479992": "0.0.10",
-  "-483287042793087855": "0.0.11",
-  "-483287042-426350137": "0.1.1",
+// Those values are from tzkt api: /v1/contracts
+type typeHash = string;
+type codeHash = string;
+
+// Before 0.0.10, the version is stored on the contract so tzip16 won't failed to retrieve it
+const VERSION_HASH: { [k: `${typeHash}:${codeHash}`]: version } = {
+  "-357299388:-2016479992": "0.0.10",
+  "-483287042:793087855": "0.0.11",
+  "-483287042:-426350137": "0.1.1",
 };
+
 async function fetchVersion(
   metadata: ContractAbstraction<ContractProvider> & {
     tzip16(
@@ -43,7 +49,7 @@ async function fetchVersion(
             ([{ typeHash, codeHash }]: {
               typeHash: number;
               codeHash: number;
-            }[]) => VERSION_HASH[`${typeHash}${codeHash}`] ?? "unknown version"
+            }[]) => VERSION_HASH[`${typeHash}:${codeHash}`] ?? "unknown version"
           )
       );
 
@@ -53,16 +59,3 @@ async function fetchVersion(
   }
 }
 export default fetchVersion;
-
-// async function fetchVersion(address: string): Promise<version> {
-//   try {
-// const { typeHash, codeHash } = (await fetch(
-// `${API_URL}/v1/contracts?address=${address}`
-// ).then(r => r.json())) as { typeHash: number; codeHash: number };
-
-//     return VERSION_HASH[`${typeHash}${codeHash}`] ?? "unknown version";
-//   } catch {
-//     return "unknown version";
-//   }
-// }
-// export default fetchVersion;

--- a/context/metadata.ts
+++ b/context/metadata.ts
@@ -21,10 +21,10 @@ const dispatch: { [key: string]: version } = {
 type typeHash = string;
 type codeHash = string;
 
-// Before 0.0.10, the version is stored on the contract so tzip16 won't failed to retrieve it
+// Before 0.0.11, the version is stored on the contract so tzip16 won't failed to retrieve it
+// typeHash and codeHash are provided by tzkt API
 const VERSION_HASH: { [k: `${typeHash}:${codeHash}`]: version } = {
-  "-357299388:-2016479992": "0.0.10",
-  "-483287042:793087855": "0.0.11",
+  "-483287042:521053333": "0.0.11",
   "-483287042:-426350137": "0.1.1",
 };
 

--- a/context/metadata.ts
+++ b/context/metadata.ts
@@ -16,6 +16,16 @@ const dispatch: { [key: string]: version } = {
   "0.1.1": "0.1.1",
 };
 
+const VERSION_HASH: { [k in version]: string } = {
+  "0.0.6": "",
+  "0.0.8": "",
+  "0.0.9": "",
+  "0.0.10": "-357299388-2016479992",
+  "0.0.11": "-483287042793087855",
+  "0.1.1": "",
+  "unknown version": "notanhash",
+};
+
 async function fetchVersion(
   metadata: ContractAbstraction<ContractProvider> & {
     tzip16(

--- a/context/metadata.ts
+++ b/context/metadata.ts
@@ -5,6 +5,7 @@ import {
 } from "@taquito/taquito";
 import { Tzip16ContractAbstraction } from "@taquito/tzip16";
 import { version } from "../types/display";
+import { API_URL } from "./config";
 
 declare const ABSTRACTION_KEY: unique symbol;
 const dispatch: { [key: string]: version } = {
@@ -16,16 +17,11 @@ const dispatch: { [key: string]: version } = {
   "0.1.1": "0.1.1",
 };
 
-const VERSION_HASH: { [k in version]: string } = {
-  "0.0.6": "",
-  "0.0.8": "",
-  "0.0.9": "",
-  "0.0.10": "-357299388-2016479992",
-  "0.0.11": "-483287042793087855",
-  "0.1.1": "",
-  "unknown version": "notanhash",
+const VERSION_HASH: { [k: string]: version } = {
+  "-357299388-2016479992": "0.0.10",
+  "-483287042793087855": "0.0.11",
+  "-483287042-426350137": "0.1.1",
 };
-
 async function fetchVersion(
   metadata: ContractAbstraction<ContractProvider> & {
     tzip16(
@@ -36,11 +32,37 @@ async function fetchVersion(
   }
 ): Promise<version> {
   try {
-    let metar = await metadata.tzip16().getMetadata();
-    let version = metar.metadata.version!;
-    return dispatch[version] || "unknown version";
+    const version = await metadata
+      .tzip16()
+      .getMetadata()
+      .then(metadata => metadata.metadata.version ?? "unknown version")
+      .catch(_ =>
+        fetch(`${API_URL}/v1/contracts?address=${metadata.address}`)
+          .then(r => r.json())
+          .then(
+            ([{ typeHash, codeHash }]: {
+              typeHash: number;
+              codeHash: number;
+            }[]) => VERSION_HASH[`${typeHash}${codeHash}`] ?? "unknown version"
+          )
+      );
+
+    return dispatch[version] ?? "unknown version";
   } catch {
     return "unknown version";
   }
 }
 export default fetchVersion;
+
+// async function fetchVersion(address: string): Promise<version> {
+//   try {
+// const { typeHash, codeHash } = (await fetch(
+// `${API_URL}/v1/contracts?address=${address}`
+// ).then(r => r.json())) as { typeHash: number; codeHash: number };
+
+//     return VERSION_HASH[`${typeHash}${codeHash}`] ?? "unknown version";
+//   } catch {
+//     return "unknown version";
+//   }
+// }
+// export default fetchVersion;

--- a/context/state.ts
+++ b/context/state.ts
@@ -137,7 +137,11 @@ function reducer(state: tezosState, action: action): tezosState {
       };
       localStorage.setItem(
         "app_state",
-        JSON.stringify({ contracts, aliases, favouriteContract: fav })
+        JSON.stringify({
+          contracts,
+          aliases,
+          currentContract: state.currentContract,
+        })
       );
       return {
         ...state,
@@ -217,7 +221,8 @@ function reducer(state: tezosState, action: action): tezosState {
       return {
         ...action.payload,
         attemptedInitialLogin: state.attemptedInitialLogin,
-        currentContract: state.currentContract,
+        currentContract:
+          state.currentContract ?? action.payload.currentContract,
         currentStorage: state.currentStorage,
         aliasTrie: Trie.fromAliases(Object.entries(action.payload.aliases)),
       };
@@ -297,7 +302,6 @@ function reducer(state: tezosState, action: action): tezosState {
     case "setAttemptedInitialLogin":
       return { ...state, attemptedInitialLogin: action.payload };
     default: {
-      console.log(action);
       throw "notImplemented";
     }
   }


### PR DESCRIPTION
# Description
This PR adds a new way to fetch version if tzip16 fail. It'll fetch tzkt api, and use `typeHash` and `codeHash` to determine the contract version.

This PR also fixes the last small issue mentioned in #123 