### PR TITLE
fix:  parsing pair data

### DIFF
--- a/tests/decodeB58.spec.ts
+++ b/tests/decodeB58.spec.ts
@@ -1,6 +1,10 @@
 import { Parser, Expr } from "@taquito/michel-codec";
 import { describe, expect, it } from "vitest";
-import { decodeB58, toRightAssociative } from "../utils/contractParam";
+import {
+  decodeB58,
+  toRightAssociativePairType,
+  toRightAssociativePairData,
+} from "../utils/contractParam";
 
 const p = new Parser();
 
@@ -387,7 +391,39 @@ describe("decodeB58 address on complicated pair data structure", () => {
   });
 });
 
-describe("test pair for right associative 1", () => {
+describe("decodeB58 address on complicated pair data structure 2", () => {
+  it("should be present in string representation", () => {
+    const instr = p.parseMichelineExpression(
+      ` { PUSH (pair string (pair string (pair string address))) (Pair "abc" "123"  "xyz" 0x000083d72f98dc41baa8b71136f05e2bc1dfd524862f)}`
+    )!;
+    const [type, data] = testData(instr);
+    const newData = decodeB58(type, data);
+
+    expect(JSON.stringify(newData)).toMatchObject(
+      JSON.stringify({
+        prim: "Pair",
+        args: [
+          { string: "abc" },
+          {
+            prim: "Pair",
+            args: [
+              { string: "123" },
+              {
+                prim: "Pair",
+                args: [
+                  { string: "xyz" },
+                  { string: "tz1Xf8zdT3DbAX9cHw3c3CXh79rc4nK4gCe8" },
+                ],
+              },
+            ],
+          },
+        ],
+      })
+    );
+  });
+});
+
+describe("test pair type for right associative 1", () => {
   it("should be right associative", () => {
     const expr = {
       prim: "pair",
@@ -411,7 +447,7 @@ describe("test pair for right associative 1", () => {
         },
       ],
     };
-    toRightAssociative(expr);
+    toRightAssociativePairType(expr);
     expect(JSON.stringify(expr)).toMatchObject(
       JSON.stringify({
         prim: "pair",
@@ -444,7 +480,7 @@ describe("test pair for right associative 1", () => {
   });
 });
 
-describe("test pair for right associative 2", () => {
+describe("test pair type for right associative 2", () => {
   it("should be right associative", () => {
     const expr = {
       prim: "pair",
@@ -463,7 +499,7 @@ describe("test pair for right associative 2", () => {
         },
       ],
     };
-    toRightAssociative(expr);
+    toRightAssociativePairType(expr);
     expect(JSON.stringify(expr)).toMatchObject(
       JSON.stringify({
         prim: "pair",
@@ -486,6 +522,75 @@ describe("test pair for right associative 2", () => {
                   {
                     prim: "address",
                   },
+                ],
+              },
+            ],
+          },
+        ],
+      })
+    );
+  });
+});
+
+describe("test pair data for right associative", () => {
+  it("should be present in string representation", () => {
+    const expr: Expr = {
+      prim: "Pair",
+      args: [
+        { string: "abc" },
+        { string: "123" },
+        { string: "xyz" },
+        { bytes: "000083d72f98dc41baa8b71136f05e2bc1dfd524862f" },
+      ],
+    };
+    const data = toRightAssociativePairData(expr);
+    expect(JSON.stringify(data)).toMatchObject(
+      JSON.stringify({
+        prim: "Pair",
+        args: [
+          { string: "abc" },
+          {
+            prim: "Pair",
+            args: [
+              { string: "123" },
+              {
+                prim: "Pair",
+                args: [
+                  { string: "xyz" },
+                  { bytes: "000083d72f98dc41baa8b71136f05e2bc1dfd524862f" },
+                ],
+              },
+            ],
+          },
+        ],
+      })
+    );
+  });
+});
+
+describe("test pair data for right associative 2", () => {
+  it("should be present in string representation", () => {
+    const expr: Expr = [
+      { string: "abc" },
+      { string: "123" },
+      { string: "xyz" },
+      { bytes: "000083d72f98dc41baa8b71136f05e2bc1dfd524862f" },
+    ];
+    const data = toRightAssociativePairData(expr);
+    expect(JSON.stringify(data)).toMatchObject(
+      JSON.stringify({
+        prim: "Pair",
+        args: [
+          { string: "abc" },
+          {
+            prim: "Pair",
+            args: [
+              { string: "123" },
+              {
+                prim: "Pair",
+                args: [
+                  { string: "xyz" },
+                  { bytes: "000083d72f98dc41baa8b71136f05e2bc1dfd524862f" },
                 ],
               },
             ],

--- a/utils/contractParam.ts
+++ b/utils/contractParam.ts
@@ -688,7 +688,7 @@ function parseContract(
  *
  *  reference: https://tezos.gitlab.io/active/michelson.html#core-data-types-and-notations
  */
-function toRightAssociative(type: Expr): void {
+function toRightAssociativePairType(type: Expr): void {
   if ("prim" in type && type.prim === "pair" && !!type.args) {
     if (type.args.length <= 2) {
       return;
@@ -697,7 +697,37 @@ function toRightAssociative(type: Expr): void {
       const left = type.args.pop();
       if (!right || !left) throw new Error("Internal: it'can happen.");
       type.args.push({ prim: "pair", args: [left, right] });
-      toRightAssociative(type);
+      toRightAssociativePairType(type);
+    }
+  } else {
+    throw new Error("Internal: not pair");
+  }
+}
+
+function toRightAssociativePairData(data: Expr): Expr {
+  if ("prim" in data && data.prim === "Pair" && !!data.args) {
+    if (data.args.length <= 2) {
+      return data;
+    } else {
+      const right = data.args.pop();
+      const left = data.args.pop();
+      if (!right || !left) throw new Error("Internal: it'can happen.");
+      data.args.push({ prim: "Pair", args: [left, right] });
+      return toRightAssociativePairData(data);
+    }
+  } else if (Array.isArray(data)) {
+    if (data.length < 2) {
+      return data;
+    } else {
+      const right = data.pop();
+      const left = data.pop();
+      if (!right || !left) throw new Error("Internal: it'can happen.");
+      if (data.length == 0) {
+        return { prim: "Pair", args: [left, right] };
+      } else {
+        data.push({ prim: "Pair", args: [left, right] });
+        return toRightAssociativePairData(data);
+      }
     }
   } else {
     throw new Error("Internal: not pair");
@@ -846,25 +876,31 @@ function decodeB58(type: Expr, data: Expr): Expr {
         }
       }
       case "pair": {
-        const new_type = toRightAssociative(type);
+        toRightAssociativePairType(type);
+        data = toRightAssociativePairData(data);
+
         if ("prim" in data && !!data.args) {
           let new_data = type.args?.map((v, i) => {
+            //@ts-expect-error
             if (!data.args?.[i]) throw new Error("Internal: should have args");
+            //@ts-expect-error
             const d = decodeB58(v, data.args[i]);
             return d;
           });
           data.args = new_data;
           return data;
         } else {
-          throw new Error("Internal: data should be a prim");
+          throw new Error("Internal: data should be a prim or array");
         }
       }
       case "option": {
         if ("prim" in data) {
           if (data.prim === "Some" && !!data.args) {
             let new_data = type.args?.map((v, i) => {
+              //@ts-expect-error
               if (!data.args?.[i])
                 throw new Error("Internal: should have args");
+              //@ts-expect-error
               const d = decodeB58(v, data.args[i]);
               return d;
             });
@@ -903,6 +939,7 @@ export {
   showName,
   parseContract,
   decodeB58,
-  toRightAssociative,
+  toRightAssociativePairType,
+  toRightAssociativePairData,
 };
 export type { token, tokenMap, tokenValueType };

--- a/utils/contractParam.ts
+++ b/utils/contractParam.ts
@@ -878,16 +878,19 @@ function decodeB58(type: Expr, data: Expr): Expr {
       case "pair": {
         toRightAssociativePairType(type);
         data = toRightAssociativePairData(data);
-
-        if ("prim" in data && !!data.args) {
+        if ("prim" in data && "args" in data) {
           let new_data = type.args?.map((v, i) => {
-            //@ts-expect-error
-            if (!data.args?.[i]) throw new Error("Internal: should have args");
-            //@ts-expect-error
-            const d = decodeB58(v, data.args[i]);
-            return d;
+            if ("prim" in data && "args" in data) {
+              if (!data.args?.[i])
+                throw new Error("Internal: should have args");
+              const d = decodeB58(v, data.args[i]);
+              return d;
+            } else {
+              throw new Error("Internal: data should be a prim or array");
+            }
           });
           data.args = new_data;
+
           return data;
         } else {
           throw new Error("Internal: data should be a prim or array");
@@ -897,12 +900,14 @@ function decodeB58(type: Expr, data: Expr): Expr {
         if ("prim" in data) {
           if (data.prim === "Some" && !!data.args) {
             let new_data = type.args?.map((v, i) => {
-              //@ts-expect-error
-              if (!data.args?.[i])
-                throw new Error("Internal: should have args");
-              //@ts-expect-error
-              const d = decodeB58(v, data.args[i]);
-              return d;
+              if ("prim" in data) {
+                if (!data.args?.[i])
+                  throw new Error("Internal: should have args");
+                const d = decodeB58(v, data.args[i]);
+                return d;
+              } else {
+                throw new Error("Internal: data should be a prim");
+              }
             });
             data.args = new_data;
           }


### PR DESCRIPTION
when the pair data represents in optimized form, `array`, the `decodeB58` will fail.

 this wallet `/KT1TCn5UfT1y7mrYBbHWrx5BQsuy8mQN2QwC` will result error on ghostnet.