### PR TITLE
[Refactor] Ipfs

### DIFF
--- a/context/config.ts
+++ b/context/config.ts
@@ -5,7 +5,7 @@ export const RPC_URL =
 export const TZKT_API_URL =
   process.env.NEXT_PUBLIC_API_URL ?? "https://api.ghostnet.tzkt.io";
 export const IPFS = "https://ipfs-proxy.gcp.marigold.dev";
-export const IPFS_NODE = "ipfs.gcp.marigold.dev";
+export const IPFS_NODE = "gateway.pinata.cloud";
 export const PREFERED_NETWORK: NetworkType =
   process.env.NEXT_PUBLIC_NETWORK_TYPE === "mainnet"
     ? NetworkType.MAINNET

--- a/context/metadata_blob.ts
+++ b/context/metadata_blob.ts
@@ -33,7 +33,7 @@ async function fromIpfs(): Promise<{
   const blob = new Blob([bytes], {
     type: "application/json;charset=utf-8",
   });
-  formData.append("file", blob, "");
+  formData.append("file", blob, "tzsafe-metdata.json");
   let { cid } = await fetch(`${IPFS}/add`, {
     method: "POST",
     body: formData,


### PR DESCRIPTION
# Description
Marigold's IPFS node is getting deprecated, so we replace it by Piniata. As all the changes are on the `ipfs-proxy`, there's not that much to change in tzsafe.
The main change is that now we rely first on the contract hash to get the version, and in a second time on the metadata if it failed.

⚠️ Before merging, we need to wait for `ipfs-proxy` to be updated by infra