### PR TITLE
:bug: redirect to first contract in list instead of last visited

### DIFF
--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -54,9 +54,7 @@ export default function App({ Component, pageProps }: AppProps) {
     const contracts = Object.keys(state.contracts);
 
     if ((path === "/" || path === "") && contracts.length > 0) {
-      const contract = !!state.currentContract
-        ? state.currentContract
-        : contracts[0];
+      const contract = contracts[0];
 
       router.replace(`/${contract}/proposals`);
       return;


### PR DESCRIPTION
Update as we talked this morning.
I'm working on separating contracts imported by the user who imported them on another branch but it's a little more complicated that I thought.