### PR TITLE
state: do not overwrite currentContract

### DIFF
--- a/context/state.ts
+++ b/context/state.ts
@@ -345,7 +345,8 @@ function reducer(state: tezosState, action: action): tezosState {
           ? storage.aliasesByUser[action.address]
           : state.aliases;
 
-      const currentContract = Object.keys(contracts).at(0) || null;
+      const currentContract =
+        state.currentContract || Object.keys(contracts).at(0) || null;
       return {
         ...state,
         balance: action.balance,


### PR DESCRIPTION
When the currentContract is already set we should not overwrite it

How to reproduce the bug:

 - start the app (make sure your local storage is empty)
 - log in with a tz1/2/3
 - do not import contracts
 - go to the url localhost:3000/KT1N4PGc2VXRq8DwrRyLo57erbMEcieNU8M7
 - The dashboard is showing 00$ (if not reload your app)
 - Go to proposals
 - The proposals page redirect to the page `invalid-contract`

What is happening is that the `login` action overwrite `currentContracts`. When the user has not yet import contracts the value is set to null, even if the user was looking to a safe

