### PR TITLE
404: directly return when auto redirect from 404

### DIFF
--- a/pages/404.tsx
+++ b/pages/404.tsx
@@ -31,6 +31,7 @@ export default function Custom404(props: any) {
     props.walletPaths.includes(page)
   ) {
     router.push(path);
+    return <></>;
   }
 
   return (


### PR DESCRIPTION
Don't return the component of the 404 page when there is a redirect